### PR TITLE
Fix hanging when a future wakes itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         rust:
-          - "1.51" # minimum stable rust version
           - stable
           - beta
     steps:
@@ -46,6 +45,24 @@ jobs:
         with:
           command: clippy
           args: --all-targets -- -D warnings
+
+  # Reduced build for the Minimum Supported Rust Version. It does not include the lints as some of
+  # them are out-of-date and result in false positives on the codebase, e.g. mutex_atomic.
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: "1.51"
+          override: true
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
 
   miri:
     name: Miri

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed potential hanging when the waker is called while polling.
+
 ## [0.1.0]
 
 - Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "It executes futures"
 repository = "https://github.com/bertptrs/beul/"
+rust-version = "1.51"
 authors = [
     "Bert Peters",
 ]

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,6 @@
+status = [
+    'MSRV',
+    'tests (stable)',
+    'tests (beta)',
+    'Miri',
+]


### PR DESCRIPTION
It's possible that either the future wakes itself or the something requests to be awoken while the future is being polled. This PR adds a bool to the waker state to track whether that happened, and will immediately unpark the executor if it did.

Also add bors for nicer merging.