### PR TITLE
Make use of pin! stabilization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: "1.51"
+          toolchain: "1.68"
 
       - run: cargo test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use dynamic dispatch internally to save on code gen. External API unchanged.
+- No longer heap-allocate futures.
+
+### Breaking
+
+- Minimum supported Rust version bumped to 1.68.
+
 ## [0.1.1] - 2022-09-05
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "beul"
 version = "0.1.1"
-# Edition 2021 is not available in MSRV
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "It executes futures"
 repository = "https://github.com/bertptrs/beul/"
-rust-version = "1.51"
+rust-version = "1.68"
 authors = [
     "Bert Peters",
 ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Beul
 
-Beul is a minimalistic futures executor. No dependencies, no unsafe rust.
+Beul is a minimalistic futures executor. No dependencies, no unsafe rust. It simply executes
+futures.
 
 ## Usage
 
@@ -12,8 +13,8 @@ beul::execute(async {});
 
 ### Backwards compatibility
 
-This crate requires at least Rust 1.51, due to its reliance on [Wake]. Increases in this version
-will be considered breaking changes. This crate follows semantic versioning.
+This crate requires at least Rust 1.68, due to its reliance on [std::pin::pin!]. Increases in this
+version will be considered breaking changes. This crate follows semantic versioning.
 
 ### Limitations
 
@@ -37,4 +38,4 @@ work by you, as defined in the Apache-2.0 license, shall be dual licensed as abo
 additional terms or conditions.
 
 [Tokio]: https://tokio.rs/
-[Wake]: https://doc.rust-lang.org/std/task/trait.Wake.html
+[std::pin::pin!]: https://doc.rust-lang.org/std/pin/macro.pin.html


### PR DESCRIPTION
With Rust 1.68 `std::pin::pin!` is stable therefore we can now use it to get rid of a pesky heap allocation in the executor.

This requires bumping MSRV to 1.68, but I feel this should be the last time that will happen, so after this I can cut the 1.0.